### PR TITLE
Add tests for CLI commands, storage, and utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ dialoguer = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3.14.0"
+assert_cmd = "2.0.4"
 
 [[bin]]
 name = "xlog"

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,184 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+#[test]
+fn test_xlog_init() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Journal initialized successfully"));
+}
+
+#[test]
+fn test_xlog_add() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("add")
+        .arg("Test entry #test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Entry 1 added"));
+}
+
+#[test]
+fn test_xlog_view() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("add")
+        .arg("Test entry #test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("view")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Test entry"));
+}
+
+#[test]
+fn test_xlog_remove() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("add")
+        .arg("Test entry #test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("remove")
+        .arg("1")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Entry 1 removed"));
+}
+
+#[test]
+fn test_xlog_edit() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("add")
+        .arg("Test entry #test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("edit")
+        .arg("1")
+        .arg("Updated entry")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Entry updated"));
+}
+
+#[test]
+fn test_xlog_search() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("add")
+        .arg("Test entry #test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("search")
+        .arg("Test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Test entry"));
+}
+
+#[test]
+fn test_xlog_export() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("add")
+        .arg("Test entry #test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("export")
+        .arg("--format")
+        .arg("json")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Journal exported successfully"));
+}
+
+#[test]
+fn test_xlog_backup() {
+    let temp_dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("init")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("add")
+        .arg("Test entry #test")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("xlog").unwrap();
+    cmd.arg("backup")
+        .arg("--action")
+        .arg("create")
+        .env("XLOG_HOME", temp_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Backup created"));
+}

--- a/tests/storage_tests.rs
+++ b/tests/storage_tests.rs
@@ -1,0 +1,45 @@
+use tempfile::tempdir;
+use std::fs;
+use std::path::PathBuf;
+use crate::storage::{self, Journal, Entry, Tag};
+
+#[test]
+fn test_load_journal() {
+    let temp_dir = tempdir().unwrap();
+    let journal_path = temp_dir.path().join("journal.json");
+    fs::write(&journal_path, "[]").unwrap();
+
+    let journal = storage::load_from_path(journal_path.clone()).unwrap();
+    assert!(journal.entries().is_empty());
+    assert_eq!(journal.path(), &journal_path);
+}
+
+#[test]
+fn test_save_journal() {
+    let temp_dir = tempdir().unwrap();
+    let journal_path = temp_dir.path().join("journal.json");
+
+    let mut journal = Journal::new(journal_path.clone());
+    journal.add_entry(Entry::new(0, "Test entry".to_string(), vec![Tag::new("test".to_string())]));
+
+    storage::save_journal(&journal).unwrap();
+    assert!(journal_path.exists());
+
+    let loaded_journal = storage::load_from_path(journal_path).unwrap();
+    assert_eq!(loaded_journal.entries().len(), 1);
+    assert_eq!(loaded_journal.entries()[0].body, "Test entry");
+    assert_eq!(loaded_journal.entries()[0].tags[0].name, "test");
+}
+
+#[test]
+fn test_init_journal() {
+    let temp_dir = tempdir().unwrap();
+    let journal_path = temp_dir.path().join("journal.json");
+    let config = storage::config::Config::default();
+
+    storage::init_journal(&config).unwrap();
+    assert!(journal_path.exists());
+
+    let journal = storage::load_from_path(journal_path).unwrap();
+    assert!(journal.entries().is_empty());
+}

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,0 +1,83 @@
+use tempfile::tempdir;
+use std::io::{self, Write};
+use crate::utils::{get_input, do_tags_match, parse_tags, parse_date, format_entry, fuzzy_match, view_by_id, print_single_entry};
+use crate::storage::{Entry, Tag, Journal};
+use crate::storage::config::JournalConfig;
+use chrono::{NaiveDate, Utc};
+
+#[test]
+fn test_get_input() {
+    let input = b"Test input\n";
+    let mut stdin = io::stdin();
+    stdin.write_all(input).unwrap();
+    let result = get_input("Enter input: ");
+    assert_eq!(result, "Test input");
+}
+
+#[test]
+fn test_do_tags_match_any() {
+    let query_tags = vec![Tag::new("test".to_string()), Tag::new("example".to_string())];
+    let entry_tags = vec![Tag::new("example".to_string()), Tag::new("sample".to_string())];
+    assert!(do_tags_match(&query_tags, &entry_tags, TagMatch::Any));
+}
+
+#[test]
+fn test_do_tags_match_all() {
+    let query_tags = vec![Tag::new("test".to_string()), Tag::new("example".to_string())];
+    let entry_tags = vec![Tag::new("test".to_string()), Tag::new("example".to_string()), Tag::new("sample".to_string())];
+    assert!(do_tags_match(&query_tags, &entry_tags, TagMatch::All));
+}
+
+#[test]
+fn test_parse_tags() {
+    let tags_str = "test example sample";
+    let tags = parse_tags(tags_str);
+    assert_eq!(tags.len(), 3);
+    assert_eq!(tags[0].name, "test");
+    assert_eq!(tags[1].name, "example");
+    assert_eq!(tags[2].name, "sample");
+}
+
+#[test]
+fn test_parse_date() {
+    let date_str = "2023-09-15";
+    let date = parse_date(date_str);
+    assert_eq!(date, NaiveDate::from_ymd(2023, 9, 15));
+}
+
+#[test]
+fn test_format_entry() {
+    let entry = Entry::new(1, "Test entry".to_string(), vec![Tag::new("test".to_string())]);
+    let config = JournalConfig { body_tags: true, show_time: true, export_dir: "exports".to_string() };
+    let formatted = format_entry(&entry, config);
+    assert!(formatted.contains("Test entry"));
+    assert!(formatted.contains("#test"));
+}
+
+#[test]
+fn test_fuzzy_match() {
+    assert!(fuzzy_match("fuzzy matching", "fuz mat"));
+    assert!(!fuzzy_match("fuzzy matching", "fuzzy not matching"));
+}
+
+#[test]
+fn test_view_by_id() {
+    let temp_dir = tempdir().unwrap();
+    let journal_path = temp_dir.path().join("journal.json");
+    let mut journal = Journal::new(journal_path.clone());
+    journal.add_entry(Entry::new(1, "Test entry".to_string(), vec![Tag::new("test".to_string())]));
+
+    let mut stdout = io::stdout();
+    let result = view_by_id(&journal, 1);
+    assert!(result.contains("Test entry"));
+}
+
+#[test]
+fn test_print_single_entry() {
+    let entry = Entry::new(1, "Test entry".to_string(), vec![Tag::new("test".to_string())]);
+    let mut stdout = io::stdout();
+    print_single_entry(&entry);
+    let output = stdout.to_string();
+    assert!(output.contains("Test entry"));
+    assert!(output.contains("#test"));
+}


### PR DESCRIPTION
Add tests for CLI commands, storage module, and utility functions.

* **CLI Tests**: Add `tests/cli_tests.rs` to test `xlog init`, `xlog add`, `xlog view`, `xlog remove`, `xlog edit`, `xlog search`, `xlog export`, and `xlog backup` commands using `assert_cmd` and `tempfile` crates.
* **Storage Tests**: Add `tests/storage_tests.rs` to test loading, saving, and initializing the journal using `tempfile` crate.
* **Utility Tests**: Add `tests/utils_tests.rs` to test `get_input`, `do_tags_match`, `parse_tags`, `parse_date`, `format_entry`, `fuzzy_match`, `view_by_id`, and `print_single_entry` functions using `tempfile` crate.
* **Dependencies**: Update `Cargo.toml` to include `assert_cmd` and `tempfile` as development dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kortgrabb/oxidlog/pull/3?shareId=ffba831c-aba7-4d05-ac92-10af7533558b).